### PR TITLE
Fix: rouge non-latin 계열 n-gram 미처리 오류 수정

### DIFF
--- a/bart_inference.py
+++ b/bart_inference.py
@@ -29,7 +29,7 @@ class BartText2TextGenerationPipeline(Text2TextGenerationPipeline):
 
 
 def main(inference_args: Tuple) -> None:
-    text = ["그러게 누가 6시까지 술을 마시래?"]
+    texts = ["그러게 누가 6시까지 술을 마시래?"]
     tokenizer = AutoTokenizer.from_pretrained(
         inference_args.model_name_or_path,
     )
@@ -69,7 +69,7 @@ def main(inference_args: Tuple) -> None:
               [`~generation_utils.GenerationMixin.constrained_beam_search`], if `constraints!=None` or
               `force_words_ids!=None`.
     """
-    pred = seq2seqlm_pipeline(text, **kwargs)
+    pred = seq2seqlm_pipeline(texts, **kwargs)
     print(pred)
 
 

--- a/bart_train.py
+++ b/bart_train.py
@@ -173,13 +173,13 @@ def main() -> None:
         labels = evaluation_result.label_ids
         reversed_labels = np.flip(labels, axis=-1)
         reversed_labels = np.where(reversed_labels != -100, reversed_labels, tokenizer.pad_token_id)
-        labels = np.where(reversed_labels != -100, reversed_labels, tokenizer.pad_token_id)
-        decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+        decoded_labels = tokenizer.batch_decode(reversed_labels, skip_special_tokens=True)
 
         blue_score = blue._compute(decoded_preds, decoded_labels)
         blue_score.pop("precisions")
 
-        rouge_score = rouge._compute(decoded_preds, decoded_labels)
+        # latin이 아닐 시, tokenizer는 split해줘야 띄어쓰기 단위로 n-gram이 정확히 계산됨
+        rouge_score = rouge._compute(decoded_preds, decoded_labels, tokenizer=lambda x: x.split())
 
         result.update(rouge_score)
         result.update(blue_score)


### PR DESCRIPTION
tokenizer 펑션을 split으로 안주면 띄어쓰기 단위로 n-gram진행이 안되서 수정합니다.
어쩐지 0.05 0.02 이렇게 나오는게 아무리 자면서 생각해봐도 납득이 안되더군요 역시 문제였음