### PR TITLE
Update: BART 최종

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ bash shell_scripts/make_trn_for_make_script.sh
 python3 preprocess.py
 ```
 ## 3. (Optional) postprocess
+```bash
+python3 postprocess.py --csv_path={your_csv_dir}/{your_csv_filename}
+```
 혹여나 추가적인 전처리 잘못 (예를들면 feature, label이외의 length 3 list혹은 2보다 작은 list) 되거나 <br />
 num과 ko 데이터가 길이가 다른경우 (뭔가 매칭이 잘못되거나 짤린 데이터) <br />
 아마 seq2seq을 이용해 학습한다면, 불필요한 문장이 예측되어 정확도가 더 떨어질 수도 있다고 판단했습니다. <br />

--- a/bart_inference.py
+++ b/bart_inference.py
@@ -38,8 +38,7 @@ def main(inference_args: Tuple) -> None:
         inference_args.model_name_or_path,
     )
 
-    if model.config.model_type == "bart":
-        print("bart의 학습은 예측 결과가 반대로 나오므로, 결과 후처리가 필요합니다.")
+    if model.config.model_type == "bart" and inference_args.direction == "backward":
         seq2seqlm_pipeline = BartText2TextGenerationPipeline(model=model, tokenizer=tokenizer)
     else:
         seq2seqlm_pipeline = Text2TextGenerationPipeline(model=model, tokenizer=tokenizer)

--- a/postprocess.py
+++ b/postprocess.py
@@ -1,5 +1,7 @@
+import os
 import csv
 import numpy as np
+import argparse
 from tqdm import tqdm
 import difflib
 import re
@@ -21,13 +23,27 @@ def tot_eda(data):
     print("범위 : ", np.max(data) - np.min(data))
 
 
-def main() -> None:
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--csv_path",
+        type=str,
+        metavar="DIR",
+        default="./data/csv/train.csv",
+        required=True,
+        help="where is your csv data dir?",
+    )
+    return parser
+
+
+def main(args) -> None:
     np_eda_ko = np.array([], dtype=int)
     np_eda_num = np.array([], dtype=int)
     np_post_ko = np.array([], dtype=int)
     np_post_num = np.array([], dtype=int)
-    csv_path = "./data/csv/out.csv"
-    post_path = "./data/csv/post_out.csv"
+    csv_path = args.csv_path
+    file_dir, file_name = os.path.split(csv_path)
+    post_path = os.path.join(file_dir, "post_" + file_name)
     f = open(csv_path, "r", encoding="utf-8")
     post_f = open(post_path, "w", newline="\n")
     wr = csv.writer(post_f)
@@ -84,4 +100,14 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = get_parser()
+    args = parser.parse_args()
+
+    def _print_config(config):
+        import pprint
+
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(vars(config))
+
+    _print_config(args)
+    main(args)

--- a/shell_scripts/run_finetuning_bart.sh
+++ b/shell_scripts/run_finetuning_bart.sh
@@ -6,26 +6,27 @@ export OMP_NUM_THREADS=8
 CUDA_VISIBLE_DEVICES=$GPU_IDS \
 python3 -m torch.distributed.launch \
 	--nproc_per_node 3 ../bart_train.py \
-	--datasets_dirs="/data2/bart/temp_workspace/nlp/KoGPT_num_converter/data/csv/post_out.csv" \
-	--model_name_or_path="/data2/bart/temp_workspace/nlp/models/kobart-base-v2" \
-	--output_dir="/data2/bart/temp_workspace/nlp/output_dir" \
+	--csv_paths="" \
+	--model_name_or_path="" \
+	--output_dir="" \
 	--overwrite_output_dir \
 	--save_total_limit="3" \
-	--max_steps="650000" \
+	--max_steps="" \
 	--save_strategy="steps" \
-	--save_steps="10000" \
+	--save_steps="" \
 	--evaluation_strategy="steps" \
-	--eval_steps="10000" \
-	--logging_steps="2000" \
-	--warmup_steps="70000" \
-	--lr_scheduler_type="cosine" \
+	--eval_steps="" \
+	--logging_steps="" \
+	--warmup_steps="" \
+	--lr_scheduler_type="" \
 	--optim="adamw_torch" \
-	--learning_rate="2e-5" \
-	--weight_decay="0" \
-	--per_device_train_batch_size="2" \
-    --gradient_accumulation_steps="1" \
-	--per_device_eval_batch_size="1" \
-	--seed="42" \
+	--adam_beta2="" \
+	--learning_rate="" \
+	--weight_decay="" \
+	--per_device_train_batch_size="" \
+    --gradient_accumulation_steps="" \
+	--per_device_eval_batch_size="" \
+	--seed="" \
     --cache_dir="./.cache" \
 	--group_by_length \
 	--fp16 \
@@ -33,10 +34,10 @@ python3 -m torch.distributed.launch \
     --load_best_model_at_end \
 	--do_train \
 	--do_eval \
-	--eval_size="0.1" \
-	--setproctitle_name="bart" \
-    --wandb_project="BartForConditionalGeneration" \
-    --wandb_entity="bart_tadev" \
-    --wandb_name="num_to_ko" \
+	--setproctitle_name="" \
+    --wandb_project="" \
+    --wandb_entity="" \
+    --wandb_name="" \
     --greater_is_better="false" \
-	--predict_with_generate="false"
+	--predict_with_generate="false" \
+	--direction="forward"

--- a/shell_scripts/run_finetuning_bart.sh
+++ b/shell_scripts/run_finetuning_bart.sh
@@ -6,26 +6,27 @@ export OMP_NUM_THREADS=8
 CUDA_VISIBLE_DEVICES=$GPU_IDS \
 python3 -m torch.distributed.launch \
 	--nproc_per_node 3 ../bart_train.py \
-	--datasets_dirs="/data2/bart/temp_workspace/nlp/KoGPT_num_converter/data/csv/post_out.csv" \
-	--model_name_or_path="/data2/bart/temp_workspace/nlp/models/kobart-base-v2" \
-	--output_dir="/data2/bart/temp_workspace/nlp/output_dir" \
+	--datasets_dirs="" \
+	--model_name_or_path="" \
+	--output_dir="" \
 	--overwrite_output_dir \
 	--save_total_limit="3" \
-	--max_steps="650000" \
+	--max_steps="" \
 	--save_strategy="steps" \
-	--save_steps="10000" \
+	--save_steps="" \
 	--evaluation_strategy="steps" \
-	--eval_steps="10000" \
-	--logging_steps="2000" \
-	--warmup_steps="70000" \
-	--lr_scheduler_type="cosine" \
+	--eval_steps="" \
+	--logging_steps="" \
+	--warmup_steps="" \
+	--lr_scheduler_type="" \
 	--optim="adamw_torch" \
-	--learning_rate="2e-5" \
-	--weight_decay="0" \
-	--per_device_train_batch_size="2" \
-    --gradient_accumulation_steps="1" \
-	--per_device_eval_batch_size="1" \
-	--seed="42" \
+	--adam_beta2="" \
+	--learning_rate="" \
+	--weight_decay="" \
+	--per_device_train_batch_size="" \
+    --gradient_accumulation_steps="" \
+	--per_device_eval_batch_size="" \
+	--seed="" \
     --cache_dir="./.cache" \
 	--group_by_length \
 	--fp16 \
@@ -34,9 +35,10 @@ python3 -m torch.distributed.launch \
 	--do_train \
 	--do_eval \
 	--eval_size="0.1" \
-	--setproctitle_name="bart" \
-    --wandb_project="BartForConditionalGeneration" \
-    --wandb_entity="bart_tadev" \
-    --wandb_name="num_to_ko" \
+	--setproctitle_name="" \
+    --wandb_project="" \
+    --wandb_entity="" \
+    --wandb_name="" \
     --greater_is_better="false" \
-	--predict_with_generate="false"
+	--predict_with_generate="false" \
+	--direction="forward"

--- a/shell_scripts/run_finetuning_bart.sh
+++ b/shell_scripts/run_finetuning_bart.sh
@@ -6,7 +6,8 @@ export OMP_NUM_THREADS=8
 CUDA_VISIBLE_DEVICES=$GPU_IDS \
 python3 -m torch.distributed.launch \
 	--nproc_per_node 3 ../bart_train.py \
-	--csv_paths="" \
+	--train_csv_paths="" \
+	--valid_csv_paths="" \
 	--model_name_or_path="" \
 	--output_dir="" \
 	--overwrite_output_dir \

--- a/shell_scripts/run_inference_bart.sh
+++ b/shell_scripts/run_inference_bart.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 python3 ../bart_inference.py \
-	--model_name_or_path="/data2/bart/temp_workspace/nlp/output_dir/checkpoint-30000" \
+	--model_name_or_path="" \
 	--beam_width="100" \
 	--min_length="0" \
 	--max_length="1206" \
 	--do_sample="false" \
-	--num_beam_groups="1"
+	--num_beam_groups="1" \
+	--direction="backward"

--- a/utils/arguments/DatasetsArguments.py
+++ b/utils/arguments/DatasetsArguments.py
@@ -4,11 +4,9 @@ from typing import List, Optional
 
 @dataclass
 class DatasetsArguments:
-    datasets_dirs: Optional[List[str]] = field(default=None)
+    train_csv_paths: Optional[List[str]] = field(default=None)
+    valid_csv_paths: Optional[List[str]] = field(default=None)
+    temp_datasets_dir: Optional[str] = field(default=None)
     vocab_path: str = field(
         default=None,
-    )
-    eval_size: float = field(default=0.0, metadata={"help": "전체 중에서 eval로 쓸 비율"})
-    test_size: float = field(
-        default=0.0, metadata={"help": "do_train: eval중에 test로 쓸 비율, not do_train: 전체 중에서 test로 쓸 비율"}
     )

--- a/utils/arguments/ModelArguments.py
+++ b/utils/arguments/ModelArguments.py
@@ -19,3 +19,7 @@ class ModelArguments:
         default=False,
         metadata={"help": "Whether to log verbose messages or not."},
     )
+    direction: Optional[str] = field(
+        default="forward",
+        metadata={"help": "How inference your label direction? default: forward [forward, backward]"},
+    )


### PR DESCRIPTION
**가장 큰 변경 사항**
@jp1924 님과 데이터 관련 처리를 논의하다가 최종 확정된 버전으로 소스 선수정하여 적용합니다.
제가 제안했던 안은, Data를 train 소스에서 train_test_split하는 방법이었으나,

**최종 선택된 안**은 @jp1924 님이 preprocess에서 train, valid split을 하도록 수정할테니,
필요한 사람에 따라 postprocess를 각각 train과 valid에 따라 돌리고, (때문에 postprocess.py가 csv 경로를 받아오도록 수정되었습니다.)
train 과정에서는 불러오기만 하자라는 것이었습니다. (때문에, 앞으로 out.csv는 생기지 않을 예정입니다.)
일단 취향차이라고 생각하기도 하고, 초반 데이터 처리쪽을 제이피님이 좀 디테일하게 수정하고싶으신 마음도 큰 것 같아 일단 제가 수용했습니다.

따라서 DatasetsArguments에서 datasets_dirs는 더 이상 사용되지 않으며, train_csv_paths와 valid_csv_paths가 추가되었습니다.
temp_datasets_dir은 매번 토크나이징 하는 것이 귀찮아서 임의로 저장해놓고 사용하기 위한 datasets_dir입니다. (아마 현재는 저만 사용할 것으로 보이네요)

**BART Model관련 변경사항**
ModelArguments에서 **direction 파라미터**가 추가되었습니다.
**Num->Text의 경우**, 여섯, 육을 분간하기 위해서는 뒤에 나올 '시', '명' 등의 명사가 중요하므로, Decoder에서 예측할때 해당 단어부터 볼 수 있도록 labels을 역순하여 반대로 예측하도록 처리합니다.
**Text -> Num의 경우**, 6은 여섯이던 육이던 무조건 6으로 가면 되기도하고, 이천오백원을 원 0052로 역순으로 출력하는게 52라던가 하는 숫자 관계상에도 혼란이 생기는 것 같아 학습이 잘 되지 않습니다. 때문에, Decoder에서 예측할때 그냥 앞에서 쭉 봅니다. (역순하지 않음)
때문에 Python 파일을 2개로 나눌까도 싶다가, 간단하게 if문으로 처리가 충분히 가능할듯 하여, 파라미터를 추가하였습니다. Optional이라 안넘겨도 동작하므로, 다른 모델 사용시에는 크게 고려할 사항은 아닐걸로 판단됩니다. (default: forward기도 하고요)

direction이 추가됨으로 발생하는 사이드 이펙트를 전부 적용하였고,
최종적으로 민감한 서버경로 전부 제거했습니다.

거의 소스가 마무리되어가고있는 것 같습니다.
